### PR TITLE
Remove start notification

### DIFF
--- a/src/discover_packages.py
+++ b/src/discover_packages.py
@@ -44,7 +44,6 @@ class PackageDiscoverer(object):
             f'Discovery started for package {self.package_id}.')
         try:
             downloaded_path = Path(self.tmp_dir, f"{self.package_id}.tar.gz")
-            self.deliver_start_notification()
             self.download(downloaded_path)
             package_path, package_data = self.unpack(downloaded_path)
             if package_data.get('origin') == 'digitization':
@@ -153,27 +152,6 @@ class PackageDiscoverer(object):
         """
         downloaded_path.unlink(missing_ok=True)
         logging.debug('Cleanup from failed job completed.')
-
-    def deliver_start_notification(self):
-        client = get_client_with_role('sns', self.sns_role_arn)
-        client.publish(
-            TopicArn=self.sns_topic,
-            Message=f'Discovery for {self.package_id} started.',
-            MessageAttributes={
-                'package_id': {
-                    'DataType': 'String',
-                    'StringValue': self.package_id,
-                },
-                'service': {
-                    'DataType': 'String',
-                    'StringValue': self.service_name,
-                },
-                'outcome': {
-                    'DataType': 'String',
-                    'StringValue': 'STARTED',
-                }
-            })
-        logging.debug('Start notification delivered.')
 
     def deliver_success_notification(self, package_data):
         """Send SNS message about successful job.

--- a/tests/test_discover_packages.py
+++ b/tests/test_discover_packages.py
@@ -45,7 +45,6 @@ def test_init():
         PackageDiscoverer(*invalid_args)
 
 
-@patch('src.discover_packages.PackageDiscoverer.deliver_start_notification')
 @patch('src.discover_packages.PackageDiscoverer.download')
 @patch('src.discover_packages.PackageDiscoverer.unpack')
 @patch('src.discover_packages.PackageDiscoverer.deliver_to_iiif_pipeline')
@@ -60,8 +59,7 @@ def test_run_born_digital(
         mock_success_cleanup,
         mock_deliver,
         mock_unpack,
-        mock_download,
-        mock_start_notification):
+        mock_download):
     """Ensures born digital packages trigger the correct methods and arguments."""
     discoverer = PackageDiscoverer(*ARGS)
     download_path = Path(discoverer.tmp_dir, f"{discoverer.package_id}.tar.gz")
@@ -77,10 +75,8 @@ def test_run_born_digital(
     mock_deliver.assert_not_called()
     mock_unpack.assert_called_once_with(download_path)
     mock_download.assert_called_once_with(download_path)
-    mock_start_notification.assert_called_once_with()
 
 
-@patch('src.discover_packages.PackageDiscoverer.deliver_start_notification')
 @patch('src.discover_packages.PackageDiscoverer.download')
 @patch('src.discover_packages.PackageDiscoverer.unpack')
 @patch('src.discover_packages.PackageDiscoverer.deliver_to_iiif_pipeline')
@@ -95,8 +91,7 @@ def test_run_digitized(
         mock_success_cleanup,
         mock_deliver,
         mock_unpack,
-        mock_download,
-        mock_start_notification):
+        mock_download):
     """Ensures digitized packages trigger the correct methods and arguments."""
     discoverer = PackageDiscoverer(*ARGS)
     download_path = Path(discoverer.tmp_dir, f"{discoverer.package_id}.tar.gz")
@@ -113,18 +108,15 @@ def test_run_digitized(
     mock_deliver.assert_called_once_with(storage_path)
     mock_unpack.assert_called_once_with(download_path)
     mock_download.assert_called_once_with(download_path)
-    mock_start_notification.assert_called_once_with()
 
 
-@patch('src.discover_packages.PackageDiscoverer.deliver_start_notification')
 @patch('src.discover_packages.PackageDiscoverer.download')
 @patch('src.discover_packages.PackageDiscoverer.cleanup_failed_job')
 @patch('src.discover_packages.PackageDiscoverer.deliver_failure_notification')
 def test_run_exception(
         mock_failure_notification,
         mock_failed_cleanup,
-        mock_download,
-        mock_start_notification):
+        mock_download):
     """Ensures exceptions are handled correctly."""
     discoverer = PackageDiscoverer(*ARGS)
     exception = Exception("Invalid refid.")
@@ -133,7 +125,6 @@ def test_run_exception(
     discoverer.run()
     mock_failure_notification.assert_called_once_with(exception)
     mock_failed_cleanup.assert_called_once_with(download_path)
-    mock_start_notification.assert_called_once_with()
 
 
 @mock_aws
@@ -222,35 +213,6 @@ def test_cleanup_failed_job():
     copy(fixture_path, tmp_path)
     discoverer.cleanup_failed_job(tmp_path)
     assert not tmp_path.is_dir()
-
-
-@mock_aws
-@patch('src.discover_packages.get_client_with_role')
-def test_deliver_start_notification(mock_role):
-    """Asserts success messages are delivered as expected."""
-    sns = boto3.client('sns', region_name='us-east-1')
-    mock_role.return_value = sns
-    topic_arn = sns.create_topic(Name='my-topic')['TopicArn']
-    sqs_conn = boto3.resource("sqs", region_name="us-east-1")
-    sqs_conn.create_queue(QueueName="test-queue")
-    sns.subscribe(
-        TopicArn=topic_arn,
-        Protocol="sqs",
-        Endpoint=f"arn:aws:sqs:us-east-1:{DEFAULT_ACCOUNT_ID}:test-queue",
-    )
-
-    default_args = ARGS
-    default_args[4] = topic_arn
-    discoverer = PackageDiscoverer(*default_args)
-
-    discoverer.deliver_start_notification()
-
-    queue = sqs_conn.get_queue_by_name(QueueName="test-queue")
-    messages = queue.receive_messages(MaxNumberOfMessages=1)
-    message_body = json.loads(messages[0].body)
-    assert message_body['MessageAttributes']['outcome']['Value'] == 'STARTED'
-    assert message_body['MessageAttributes']['package_id']['Value'] == discoverer.package_id
-    assert message_body['MessageAttributes']['service']['Value'] == discoverer.service_name
 
 
 @mock_aws


### PR DESCRIPTION
Because there is no package data already present in the Zodiac Backend API when this service starts, we cannot send a start notification message because the data delivered to the Zodiac API by that message will be missing required attributes, which are only available at the conclusion of this service run.