### PR TITLE
Convert base image to Alpine and update to Python 3.12

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: pip
 
       - name: Install pre-commit and pip-tools

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Cache dependencies
         uses: actions/cache@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-alpine AS base
+FROM python:3.12-alpine AS base
 WORKDIR /code
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-buster AS base
+FROM python:3.11-alpine AS base
 WORKDIR /code
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@ A microservice to discover packages.
 
 ## Getting Started
 
-If you have [git](https://git-scm.com/) and [Docker](https://www.docker.com/community-edition) installed, using this repository is as simple as:
+If you have [git](https://git-scm.com/) and [Docker](https://www.docker.com/community-edition) installed, you can run the application using:
 
 ```
 git clone https://github.com/RockefellerArchiveCenter/digital_ingest_discovery.git
 cd digital_ingest_discovery
+git submodule update --init
 docker build -t digital_ingest_discovery .
 docker run digital_ingest_discovery
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,20 +1,20 @@
-attrs==25.3.0
+attrs==25.4.0
     # via
     #   jsonschema
     #   referencing
 aws-assume-role-lib==2.10.0
     # via -r requirements.in
-boto3==1.40.42
+boto3==1.40.53
     # via aws-assume-role-lib
-botocore==1.40.42
+botocore==1.40.53
     # via
     #   boto3
     #   s3transfer
-certifi==2025.8.3
+certifi==2025.10.5
     # via requests
-charset-normalizer==3.4.3
+charset-normalizer==3.4.4
     # via requests
-idna==3.10
+idna==3.11
     # via requests
 jmespath==1.0.1
     # via
@@ -28,7 +28,7 @@ python-dateutil==2.9.0.post0
     # via botocore
 rac-schema-validator==1.0
     # via -r requirements.in
-referencing==0.36.2
+referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ passenv =
   USER
 commands =
   docker build -t digital_ingest_discovery_test --target test .
-  docker run digital_ingest_discovery_test bash -c "coverage run -m pytest -s && coverage report -m"
+  docker run digital_ingest_discovery_test sh -c "coverage run -m pytest -s && coverage report -m"
 
 [testenv:linting]
 allowlist_externals = pre-commit

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
-envlist = py311, linting
+envlist = py312, linting
 skipsdist = True
 
 [testenv]
 skip_install = True
 
-[testenv:py311]
+[testenv:py312]
 allowlist_externals = docker
 passenv =
   USER


### PR DESCRIPTION
Converts Docker base image to Alpine, requiring the use of sh instead of bash.

Also updates from python 3.11 to 3.12 and adds the addition of rac_schemas submodule to the readme.