### PR TITLE
feat: Adds ArchivesSpace ref ID to identifiers array

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,4 @@
+ArchivesSnake~=0.10
 aws_assume_role_lib~=2.10
 rac-schema-validator~=1.0
 requests~=2.27

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,20 +1,25 @@
+archivessnake==0.10.1
+    # via -r requirements.in
 attrs==26.1.0
     # via
+    #   archivessnake
     #   jsonschema
     #   referencing
 aws-assume-role-lib==2.10.0
     # via -r requirements.in
-boto3==1.43.18
+boltons==26.0.0
+    # via archivessnake
+boto3==1.43.36
     # via aws-assume-role-lib
-botocore==1.43.18
+botocore==1.43.36
     # via
     #   boto3
     #   s3transfer
-certifi==2026.5.20
+certifi==2026.6.17
     # via requests
 charset-normalizer==3.4.7
     # via requests
-idna==3.17
+idna==3.18
     # via requests
 jmespath==1.1.0
     # via
@@ -24,26 +29,36 @@ jsonschema==4.26.0
     # via rac-schema-validator
 jsonschema-specifications==2025.9.1
     # via jsonschema
+more-itertools==11.1.0
+    # via archivessnake
 python-dateutil==2.9.0.post0
     # via botocore
-rac-schema-validator==1.1.1
+pyyaml==6.0.3
+    # via archivessnake
+rac-schema-validator==1.1.2
     # via -r requirements.in
+rapidfuzz==3.14.5
+    # via archivessnake
 referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
 requests==2.34.2
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   archivessnake
 rpds-py==2026.5.1
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.18.0
+s3transfer==0.19.0
     # via boto3
 shortuuid==1.0.13
     # via -r requirements.in
 six==1.17.0
     # via python-dateutil
+structlog==26.1.0
+    # via archivessnake
 typing-extensions==4.15.0
     # via referencing
 urllib3==2.7.0

--- a/src/discover_packages.py
+++ b/src/discover_packages.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import rac_schema_validator
 import shortuuid
+from asnake.aspace import ASpace
 
 from src.helpers import get_client_with_role, validate_package_data
 
@@ -19,6 +20,9 @@ class PackageDiscoverer(object):
 
     def __init__(self,
                  package_id,
+                 as_baseurl,
+                 as_username,
+                 as_password,
                  iiif_bucket,
                  s3_role_arn,
                  sns_role_arn,
@@ -35,6 +39,10 @@ class PackageDiscoverer(object):
         self.source_bucket = source_bucket
         self.assembly_bucket = assembly_bucket
         self.ebs_path = ebs_path
+        self.as_client = ASpace(
+            baseurl=as_baseurl,
+            username=as_username,
+            password=as_password).client
 
     def run(self):
         logging.debug(
@@ -94,6 +102,10 @@ class PackageDiscoverer(object):
                 package_data['identifiers'] = {}
             package_data['identifiers'].update({'archivesspace_archival_object': as_uri})
 
+            """Add ArchivesSpace Ref ID"""
+            as_ref_id = self.get_as_ref_id(as_uri)
+            package_data['identifiers'].update({'archivesspace_ref_id': as_ref_id})
+
             """Add DIMES ID to identifiers"""
             package_data['identifiers'].update({'dimes_object': shortuuid.uuid(name=as_uri)})
 
@@ -119,6 +131,11 @@ class PackageDiscoverer(object):
                 f"{self.package_id}.tar.gz",
                 ExtraArgs={'ContentType': 'application/gzip'})
         return extracted_path, package_data
+
+    def get_as_ref_id(self, as_uri):
+        """Get Ref ID from ArchivesSpace."""
+        obj = self.as_client.get(as_uri).json()
+        return obj['ref_id']
 
     def deliver_to_iiif_pipeline(self, package_filepath):
         """Deliver package to digitization services.
@@ -222,6 +239,9 @@ class PackageDiscoverer(object):
 
 if __name__ == '__main__':
     package_id = os.environ.get('PACKAGE_ID')
+    as_baseurl = os.environ.get('AS_BASEURL')
+    as_username = os.environ.get('AS_USERNAME')
+    as_password = os.environ.get('AS_PASSWORD')
     iiif_bucket = os.environ.get('AWS_IIIF_BUCKET')
     s3_role_arn = os.environ.get('AWS_S3_ROLE_ARN')
     sns_role_arn = os.environ.get('AWS_SNS_ROLE_ARN')
@@ -232,6 +252,9 @@ if __name__ == '__main__':
 
     PackageDiscoverer(
         package_id,
+        as_baseurl,
+        as_username,
+        as_password,
         iiif_bucket,
         s3_role_arn,
         sns_role_arn,

--- a/tests/fixtures/json/f78742e5-6af9-4756-a94a-6cd297406d50.json
+++ b/tests/fixtures/json/f78742e5-6af9-4756-a94a-6cd297406d50.json
@@ -33,6 +33,7 @@
     "archivesspace_identifier": "/repositories/2/archival_objects/1150893",
     "identifiers": {
         "archivesspace_archival_object": "/repositories/2/archival_objects/1150893",
+        "archivesspace_ref_id": "123456",
         "dimes_object": "GdHEBKuZWWta5qeo4xfcQ3"
     }
 }

--- a/tests/fixtures/json/f78742e5-6af9-4756-a94a-6cd297406d51.json
+++ b/tests/fixtures/json/f78742e5-6af9-4756-a94a-6cd297406d51.json
@@ -144,6 +144,7 @@
     "identifiers": {
         "aurora_package": "https://aurora.rockarch.org/api/transfers/19/", 
         "archivesspace_archival_object": "/repositories/2/archival_objects/1150893",
+        "archivesspace_ref_id": "123456",
         "dimes_object": "GdHEBKuZWWta5qeo4xfcQ3"
     }
 }

--- a/tests/test_discover_packages.py
+++ b/tests/test_discover_packages.py
@@ -27,10 +27,12 @@ ARGS = [
 ]
 
 
+@patch('asnake.client.ASnakeClient.get')
 @patch('asnake.client.ASnakeClient.authorize')
-def test_init(mock_as):
+def test_init(mock_as, mock_get):
     """Asserts Validator init method sets attributes correctly."""
     mock_as.return_value = True
+    mock_get.return_value.text = "v.4.2.0"
     discoverer = PackageDiscoverer(*ARGS)
     assert discoverer.package_id == 'f78742e5-6af9-4756-a94a-6cd297406d50'
     assert discoverer.iiif_bucket == 'rac-dev-iiif-upload'
@@ -62,9 +64,11 @@ def test_init(mock_as):
 @patch('src.discover_packages.PackageDiscoverer.cleanup_successful_job')
 @patch('src.discover_packages.PackageDiscoverer.deliver_success_notification')
 @patch('src.discover_packages.PackageDiscoverer.deliver_failure_notification')
+@patch('asnake.client.ASnakeClient.get')
 @patch('asnake.client.ASnakeClient.authorize')
 def test_run_born_digital(
         mock_as_auth,
+        mock_get,
         mock_failure_notification,
         mock_success_notification,
         mock_success_cleanup,
@@ -74,6 +78,7 @@ def test_run_born_digital(
         mock_download):
     """Ensures born digital packages trigger the correct methods and arguments."""
     mock_as_auth.return_value = True
+    mock_get.return_value.text = "v.4.2.0"
     discoverer = PackageDiscoverer(*ARGS)
     download_path = Path(discoverer.ebs_path, f"{discoverer.package_id}.tar.gz")
     package_data = {"origin": "aurora"}
@@ -99,9 +104,11 @@ def test_run_born_digital(
 @patch('src.discover_packages.PackageDiscoverer.cleanup_successful_job')
 @patch('src.discover_packages.PackageDiscoverer.deliver_success_notification')
 @patch('src.discover_packages.PackageDiscoverer.deliver_failure_notification')
+@patch('asnake.client.ASnakeClient.get')
 @patch('asnake.client.ASnakeClient.authorize')
 def test_run_digitized(
         mock_as_auth,
+        mock_get,
         mock_failure_notification,
         mock_success_notification,
         mock_success_cleanup,
@@ -111,6 +118,7 @@ def test_run_digitized(
         mock_download):
     """Ensures digitized packages trigger the correct methods and arguments."""
     mock_as_auth.return_value = True
+    mock_get.return_value.text = "v.4.2.0"
     discoverer = PackageDiscoverer(*ARGS)
     download_path = Path(discoverer.ebs_path, f"{discoverer.package_id}.tar.gz")
     package_data = {"origin": "digitization"}
@@ -131,13 +139,16 @@ def test_run_digitized(
 
 @patch('src.discover_packages.PackageDiscoverer.download')
 @patch('src.discover_packages.PackageDiscoverer.deliver_failure_notification')
+@patch('asnake.client.ASnakeClient.get')
 @patch('asnake.client.ASnakeClient.authorize')
 def test_run_exception(
         mock_as,
+        mock_get,
         mock_failure_notification,
         mock_download):
     """Ensures exceptions are handled correctly."""
     mock_as.return_value = True
+    mock_get.return_value.text = "v.4.2.0"
     discoverer = PackageDiscoverer(*ARGS)
     exception = Exception("Invalid refid.")
     mock_download.side_effect = exception
@@ -147,9 +158,11 @@ def test_run_exception(
 
 @mock_aws
 @patch('src.discover_packages.get_client_with_role')
+@patch('asnake.client.ASnakeClient.get')
 @patch('asnake.client.ASnakeClient.authorize')
-def test_download(mock_as, mock_role):
+def test_download(mock_as, mock_get, mock_role):
     mock_as.return_value = True
+    mock_get.return_value.text = "v.4.2.0"
     discoverer = PackageDiscoverer(*ARGS)
     s3 = boto3.client('s3', region_name='us-east-1')
     mock_role.return_value = s3
@@ -166,10 +179,12 @@ def test_download(mock_as, mock_role):
 
 @mock_aws
 @patch('src.discover_packages.PackageDiscoverer.get_as_ref_id')
+@patch('asnake.client.ASnakeClient.get')
 @patch('asnake.client.ASnakeClient.authorize')
-def test_unpack(mock_as, mock_refid):
+def test_unpack(mock_as, mock_get, mock_refid):
     """Tests unpacking for both aurora and digitization package."""
     mock_as.return_value = True
+    mock_get.return_value.text = "v.4.2.0"
     mock_refid.return_value = "123456"
     discoverer = PackageDiscoverer(*ARGS)
     for identifier in ["f78742e5-6af9-4756-a94a-6cd297406d50", "f78742e5-6af9-4756-a94a-6cd297406d51"]:
@@ -199,10 +214,12 @@ def test_unpack(mock_as, mock_refid):
 
 
 @mock_aws
+@patch('asnake.client.ASnakeClient.get')
 @patch('asnake.client.ASnakeClient.authorize')
-def test_deliver_to_iiif_pipeline(mock_as):
+def test_deliver_to_iiif_pipeline(mock_as, mock_get):
     """Tests binary is correctly moved and POST request is sent with correct data."""
     mock_as.return_value = True
+    mock_get.return_value.text = "v.4.2.0"
     discoverer = PackageDiscoverer(*ARGS)
     fixture_path = Path(
         "tests",
@@ -218,9 +235,11 @@ def test_deliver_to_iiif_pipeline(mock_as):
         Key=f"{discoverer.package_id}.tar.gz")
 
 
+@patch('asnake.client.ASnakeClient.get')
 @patch('asnake.client.ASnakeClient.authorize')
-def test_get_package_size(mock_as):
+def test_get_package_size(mock_as, mock_get):
     mock_as.return_value = True
+    mock_get.return_value.text = "v.4.2.0"
     fixture_path = fixture_path = Path(
         "tests",
         "fixtures",
@@ -233,10 +252,12 @@ def test_get_package_size(mock_as):
 
 @mock_aws
 @patch('src.discover_packages.get_client_with_role')
+@patch('asnake.client.ASnakeClient.get')
 @patch('asnake.client.ASnakeClient.authorize')
-def test_cleanup_successful_job(mock_as, mock_role):
+def test_cleanup_successful_job(mock_as, mock_get, mock_role):
     """Ensures file are cleaned up as expected."""
     mock_as.return_value = True
+    mock_get.return_value.text = "v.4.2.0"
     discoverer = PackageDiscoverer(*ARGS)
     s3 = boto3.client('s3', region_name='us-east-1')
     mock_role.return_value = s3
@@ -257,10 +278,12 @@ def test_cleanup_successful_job(mock_as, mock_role):
 
 @mock_aws
 @patch('src.discover_packages.get_client_with_role')
+@patch('asnake.client.ASnakeClient.get')
 @patch('asnake.client.ASnakeClient.authorize')
-def test_deliver_success_notification(mock_as, mock_role):
+def test_deliver_success_notification(mock_as, mock_get, mock_role):
     """Asserts success messages are delivered as expected."""
     mock_as.return_value = True
+    mock_get.return_value.text = "v.4.2.0"
     sns = boto3.client('sns', region_name='us-east-1')
     mock_role.return_value = sns
     topic_arn = sns.create_topic(
@@ -307,11 +330,13 @@ def test_deliver_success_notification(mock_as, mock_role):
 @mock_aws
 @patch('src.discover_packages.get_client_with_role')
 @patch('traceback.format_exception')
+@patch('asnake.client.ASnakeClient.get')
 @patch('asnake.client.ASnakeClient.authorize')
-def test_deliver_failure_notification(mock_as, mock_traceback, mock_role):
+def test_deliver_failure_notification(mock_as, mock_get, mock_traceback, mock_role):
     """Asserts failure messages are delivered as expected."""
     sns = boto3.client('sns', region_name='us-east-1')
     mock_as.return_value = True
+    mock_get.return_value.text = "v.4.2.0"
     mock_role.return_value = sns
     topic_arn = sns.create_topic(
         Name='my-topic.fifo',

--- a/tests/test_discover_packages.py
+++ b/tests/test_discover_packages.py
@@ -2,7 +2,7 @@ import io
 import json
 from pathlib import Path
 from shutil import copy
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import boto3
 import pytest
@@ -14,6 +14,9 @@ from src.discover_packages import PackageDiscoverer
 
 ARGS = [
     'f78742e5-6af9-4756-a94a-6cd297406d50',  # package_id
+    'https://as.rockarch.org/api',  # AS baseurl
+    'admin',  # AS username
+    'admin',  # AS password
     'rac-dev-iiif-upload',  # iiif-bucket
     'digital-ingest-discovery-dev-s3-role-arn',  # s3_role_arn
     'digital-ingest-discovery-dev-sns-role-arn',  # sns_role_arn
@@ -24,8 +27,10 @@ ARGS = [
 ]
 
 
-def test_init():
+@patch('asnake.client.ASnakeClient.authorize')
+def test_init(mock_as):
     """Asserts Validator init method sets attributes correctly."""
+    mock_as.return_value = True
     discoverer = PackageDiscoverer(*ARGS)
     assert discoverer.package_id == 'f78742e5-6af9-4756-a94a-6cd297406d50'
     assert discoverer.iiif_bucket == 'rac-dev-iiif-upload'
@@ -38,6 +43,9 @@ def test_init():
 
     invalid_args = [
         'f78742e5-6af9-4756-a94a-6cd297406d50',
+        'https://as.rockarch.org/api',
+        'admin',
+        'admin'
         'digital-ingest-discovery-dev-role-arn',
         'topic',
         'digital-ingest-upload',
@@ -54,7 +62,9 @@ def test_init():
 @patch('src.discover_packages.PackageDiscoverer.cleanup_successful_job')
 @patch('src.discover_packages.PackageDiscoverer.deliver_success_notification')
 @patch('src.discover_packages.PackageDiscoverer.deliver_failure_notification')
+@patch('asnake.client.ASnakeClient.authorize')
 def test_run_born_digital(
+        mock_as_auth,
         mock_failure_notification,
         mock_success_notification,
         mock_success_cleanup,
@@ -63,6 +73,7 @@ def test_run_born_digital(
         mock_unpack,
         mock_download):
     """Ensures born digital packages trigger the correct methods and arguments."""
+    mock_as_auth.return_value = True
     discoverer = PackageDiscoverer(*ARGS)
     download_path = Path(discoverer.ebs_path, f"{discoverer.package_id}.tar.gz")
     package_data = {"origin": "aurora"}
@@ -88,7 +99,9 @@ def test_run_born_digital(
 @patch('src.discover_packages.PackageDiscoverer.cleanup_successful_job')
 @patch('src.discover_packages.PackageDiscoverer.deliver_success_notification')
 @patch('src.discover_packages.PackageDiscoverer.deliver_failure_notification')
+@patch('asnake.client.ASnakeClient.authorize')
 def test_run_digitized(
+        mock_as_auth,
         mock_failure_notification,
         mock_success_notification,
         mock_success_cleanup,
@@ -97,6 +110,7 @@ def test_run_digitized(
         mock_unpack,
         mock_download):
     """Ensures digitized packages trigger the correct methods and arguments."""
+    mock_as_auth.return_value = True
     discoverer = PackageDiscoverer(*ARGS)
     download_path = Path(discoverer.ebs_path, f"{discoverer.package_id}.tar.gz")
     package_data = {"origin": "digitization"}
@@ -117,10 +131,13 @@ def test_run_digitized(
 
 @patch('src.discover_packages.PackageDiscoverer.download')
 @patch('src.discover_packages.PackageDiscoverer.deliver_failure_notification')
+@patch('asnake.client.ASnakeClient.authorize')
 def test_run_exception(
+        mock_as,
         mock_failure_notification,
         mock_download):
     """Ensures exceptions are handled correctly."""
+    mock_as.return_value = True
     discoverer = PackageDiscoverer(*ARGS)
     exception = Exception("Invalid refid.")
     mock_download.side_effect = exception
@@ -130,7 +147,9 @@ def test_run_exception(
 
 @mock_aws
 @patch('src.discover_packages.get_client_with_role')
-def test_download(mock_role):
+@patch('asnake.client.ASnakeClient.authorize')
+def test_download(mock_as, mock_role):
+    mock_as.return_value = True
     discoverer = PackageDiscoverer(*ARGS)
     s3 = boto3.client('s3', region_name='us-east-1')
     mock_role.return_value = s3
@@ -146,8 +165,12 @@ def test_download(mock_role):
 
 
 @mock_aws
-def test_unpack():
+@patch('src.discover_packages.PackageDiscoverer.get_as_ref_id')
+@patch('asnake.client.ASnakeClient.authorize')
+def test_unpack(mock_as, mock_refid):
     """Tests unpacking for both aurora and digitization package."""
+    mock_as.return_value = True
+    mock_refid.return_value = "123456"
     discoverer = PackageDiscoverer(*ARGS)
     for identifier in ["f78742e5-6af9-4756-a94a-6cd297406d50", "f78742e5-6af9-4756-a94a-6cd297406d51"]:
         discoverer.package_id = identifier
@@ -169,10 +192,17 @@ def test_unpack():
             assert package_data == expected_data
         assert s3.head_object(Bucket=discoverer.assembly_bucket, Key=f"{discoverer.package_id}.tar.gz")
 
+    mock_refid.assert_has_calls([
+        call('/repositories/2/archival_objects/1150893'),
+        call('/repositories/2/archival_objects/1150893')
+    ])
+
 
 @mock_aws
-def test_deliver_to_iiif_pipeline():
+@patch('asnake.client.ASnakeClient.authorize')
+def test_deliver_to_iiif_pipeline(mock_as):
     """Tests binary is correctly moved and POST request is sent with correct data."""
+    mock_as.return_value = True
     discoverer = PackageDiscoverer(*ARGS)
     fixture_path = Path(
         "tests",
@@ -188,7 +218,9 @@ def test_deliver_to_iiif_pipeline():
         Key=f"{discoverer.package_id}.tar.gz")
 
 
-def test_get_package_size():
+@patch('asnake.client.ASnakeClient.authorize')
+def test_get_package_size(mock_as):
+    mock_as.return_value = True
     fixture_path = fixture_path = Path(
         "tests",
         "fixtures",
@@ -201,8 +233,10 @@ def test_get_package_size():
 
 @mock_aws
 @patch('src.discover_packages.get_client_with_role')
-def test_cleanup_successful_job(mock_role):
+@patch('asnake.client.ASnakeClient.authorize')
+def test_cleanup_successful_job(mock_as, mock_role):
     """Ensures file are cleaned up as expected."""
+    mock_as.return_value = True
     discoverer = PackageDiscoverer(*ARGS)
     s3 = boto3.client('s3', region_name='us-east-1')
     mock_role.return_value = s3
@@ -223,8 +257,10 @@ def test_cleanup_successful_job(mock_role):
 
 @mock_aws
 @patch('src.discover_packages.get_client_with_role')
-def test_deliver_success_notification(mock_role):
+@patch('asnake.client.ASnakeClient.authorize')
+def test_deliver_success_notification(mock_as, mock_role):
     """Asserts success messages are delivered as expected."""
+    mock_as.return_value = True
     sns = boto3.client('sns', region_name='us-east-1')
     mock_role.return_value = sns
     topic_arn = sns.create_topic(
@@ -250,7 +286,7 @@ def test_deliver_success_notification(mock_role):
     )
 
     default_args = ARGS
-    default_args[4] = topic_arn
+    default_args[7] = topic_arn
     discoverer = PackageDiscoverer(*default_args)
 
     package_data = {}
@@ -271,9 +307,11 @@ def test_deliver_success_notification(mock_role):
 @mock_aws
 @patch('src.discover_packages.get_client_with_role')
 @patch('traceback.format_exception')
-def test_deliver_failure_notification(mock_traceback, mock_role):
+@patch('asnake.client.ASnakeClient.authorize')
+def test_deliver_failure_notification(mock_as, mock_traceback, mock_role):
     """Asserts failure messages are delivered as expected."""
     sns = boto3.client('sns', region_name='us-east-1')
+    mock_as.return_value = True
     mock_role.return_value = sns
     topic_arn = sns.create_topic(
         Name='my-topic.fifo',
@@ -298,7 +336,7 @@ def test_deliver_failure_notification(mock_traceback, mock_role):
     )
 
     default_args = ARGS
-    default_args[4] = topic_arn
+    default_args[7] = topic_arn
     discoverer = PackageDiscoverer(*default_args)
     exception_message = "foo"
     exception = Exception(exception_message)


### PR DESCRIPTION
Adds the refid for an ArchivesSpace object to the identifiers sent to Zodiac. This supports work necessary to address RockefellerArchiveCenter/zodiac_frontend#86